### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/bytemain/prog/security/code-scanning/3](https://github.com/bytemain/prog/security/code-scanning/3)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in the workflow to the minimal set required. These jobs only need to read the repository contents to check out the code and run Rust tooling, so we can safely set `contents: read` at the workflow level. Adding a top-level `permissions:` block will apply to all jobs that don’t override it, so we only need one block near the top of `.github/workflows/ci.yml`.

Concretely, in `.github/workflows/ci.yml`, add a root-level `permissions:` section after the `name: CI` line (or before `on:`). Set `contents: read`. No other permissions appear necessary for these jobs, since they don’t interact with issues, PRs, or packages. No imports or additional methods are needed, as this is purely YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
